### PR TITLE
Properly wait for google charts service to load.

### DIFF
--- a/addon/services/google-charts.js
+++ b/addon/services/google-charts.js
@@ -27,7 +27,7 @@ export default Ember.Service.extend({
 
         this.get('_callbacksAddedWhileLoading').push(resolve);
       } else {
-        this.set('_calledLoad', true);
+        this.set('_loadInProgress', true);
 
         google.charts.load('current', {
           language: this.get('language'),


### PR DESCRIPTION
I was having a problem rendering two charts together. The nonexistent field "_calledLoad" was being used instead of the "_loadInProgress" field. I've tested this in my code and it works as expected.

To reproduce the problem, try rendering two chart components together. On Chrome, the console outputs the error "google.charts.load() cannot be called more than once."