### PR TITLE
Fix deprecation warning for Ember.warn()

### DIFF
--- a/addon/components/google-chart.js
+++ b/addon/components/google-chart.js
@@ -69,8 +69,9 @@ export default Ember.Component.extend({
 
   setupDependencies() {
     const type = this.get('type');
+    const options = { id: 'setup-dependencies' };
 
-    Ember.warn('You did not specify a chart type', type);
+    Ember.warn('You did not specify a chart type', type, options);
 
     this.get('googleCharts').loadPackages().then(() => {
       this.sendAction('packagesDidLoad');


### PR DESCRIPTION
In reference to issue https://github.com/sir-dunxalot/ember-google-charts/issues/20