### PR TITLE
Allow data tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ See the [demo app](http://sir-dunxalot.github.io/ember-google-charts/) here.
 
 There are six types of chart supported out of the box:
 
-- Area Charts
-- Bar Charts
-- Geo Charts
-- Line Charts
-- Pie Charts
-- Scatter Charts
+- Area Charts (`{{area-chart}}`)
+- Bar Charts (`{{bar-chart}}`)
+- Geo Charts (`{{geo-chart}}`)
+- Line Charts (`{{line-chart}}`)
+- Pie Charts (`{{pie-chart}}`)
+- Scatter Charts (`{{scatter-chart}}`)
 
 To add a chart to any route, simply add the relevant component:
 
@@ -96,6 +96,34 @@ export default Route.extend({
 
 {{pie-chart data=data options=options}}
 ```
+
+You can pass data as an array (see above example) or as a [Google Data Table](https://developers.google.com/chart/interactive/docs/datatables_dataviews):
+
+```js
+/* stats/route.js */
+
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+
+  model() {
+    return google.visualization.arrayToDataTable([
+      ['Year', 'Sales', 'Expenses'],
+      ['2004', 1000, 400],
+      ['2005', 1170, 460],
+    ], false);
+  },
+
+});
+```
+
+```hbs
+{{!-- stats/template.hbs --}}
+
+{{pie-chart data=data}}
+```
+
+For more information about data tables and how to create them, see the [Google Charts guides](https://developers.google.com/chart/interactive/docs/datatables_dataviews).
 
 Where possible, this addon default to using Material Charts over Google's 'classic' design.
 

--- a/addon/utils/render-classic-chart.js
+++ b/addon/utils/render-classic-chart.js
@@ -7,7 +7,14 @@ export default function renderClassicChart(data, options) {
     const type = this.get('type');
     const visualizationName = VisualizationNames[type];
     const chart = new visualization[visualizationName](this.get('element'));
-    const dataTable = visualization.arrayToDataTable(data);
+
+    let dataTable;
+
+    if (data instanceof visualization.DataTable) {
+      dataTable = data;
+    } else {
+      dataTable = visualization.arrayToDataTable(data);
+    }
 
     visualization.events.addListener(chart, 'error', reject);
 

--- a/addon/utils/render-material-chart.js
+++ b/addon/utils/render-material-chart.js
@@ -5,7 +5,14 @@ export default function renderMaterialChart(data, options) {
   return new RSVP.Promise((resolve, reject) => {
     const { charts, visualization } = window.google;
     const type = capitalize(this.get('type'));
-    const dataTable = visualization.arrayToDataTable(data);
+
+    let dataTable;
+
+    if (data instanceof visualization.DataTable) {
+      dataTable = data;
+    } else {
+      dataTable = visualization.arrayToDataTable(data);
+    }
 
     let chart = this.get('chart');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-google-charts",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3181,18 +3181,6 @@
       "requires": {
         "ember-cli-version-checker": "2.1.2",
         "rsvp": "4.8.3"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
-          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
-          "dev": true,
-          "requires": {
-            "resolve": "1.8.1",
-            "semver": "5.5.1"
-          }
-        }
       }
     },
     "ember-cli-htmlbars": {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -6,7 +6,7 @@
 
         <li class="page-header-logo">
           {{#link-to 'index'}}
-            <img src="/ember.png" class="logo" height="30"/>
+            <img src="ember.png" class="logo" height="30"/>
             <h2 class="text">&nbsp;Google Charts</h2>
           {{/link-to}}
         </li>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -52,6 +52,8 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
+    ENV.locationType = 'hash';
+    ENV.rootURL = '/ember-google-charts/';
     // here you can enable a production-specific feature
   }
 

--- a/tests/integration/pass-in-data-table-test.js
+++ b/tests/integration/pass-in-data-table-test.js
@@ -1,0 +1,98 @@
+import { later } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Pass in Google DataTable', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const dataArray = [
+    ['Year', 'Sales', 'Expenses'],
+    ['2004', 1000, 400],
+    ['2005', 1170, 460],
+  ];
+
+  const newDataArray = [
+    ['Year', 'Sales', 'Expenses'],
+    ['2008', 1000, 400],
+    ['2009', 1170, 460],
+  ];
+
+  test('Passing in data to a Material Chart', async function(assert) {
+
+    assert.expect(2);
+
+    /* Render a chart with data passed as a JS Array */
+
+    this.set('data', dataArray);
+
+    await render(hbs`{{bar-chart data=data options=options}}`);
+
+    await waitFor('.google-chart svg');
+
+    await new Promise((resolve) => {
+      later(resolve, 1000);
+    });
+
+    const $component = this.$('.google-chart');
+
+    assert.ok($component.text().indexOf('2004') > -1,
+      'The chart should be rendered with the data from the array');
+
+    /* Render a chart with data passed as a Google DataTable */
+
+    const dataTable = window.google.visualization.arrayToDataTable(newDataArray, false);
+
+    this.set('data', dataTable);
+
+    await settled();
+
+    await new Promise((resolve) => {
+      later(resolve, 1000);
+    });
+
+    assert.ok($component.text().indexOf('2008') > -1,
+      'The chart should be rendered with the data from the DataTable');
+
+  });
+
+    test('Passing in data to a Classic Chart', async function(assert) {
+
+    assert.expect(2);
+
+    /* Render a chart with data passed as a JS Array */
+
+    this.set('data', dataArray);
+
+    await render(hbs`{{pie-chart data=data options=options}}`);
+
+    await waitFor('.google-chart svg');
+
+    await new Promise((resolve) => {
+      later(resolve, 1000);
+    });
+
+    const $component = this.$('.google-chart');
+
+    assert.ok($component.text().indexOf('2004') > -1,
+      'The chart should be rendered with the data from the array');
+
+    /* Render a chart with data passed as a Google DataTable */
+
+    const dataTable = window.google.visualization.arrayToDataTable(newDataArray, false);
+
+    this.set('data', dataTable);
+
+    await settled();
+
+    await new Promise((resolve) => {
+      later(resolve, 1000);
+    });
+
+    assert.ok($component.text().indexOf('2008') > -1,
+      'The chart should be rendered with the data from the DataTable');
+
+  });
+
+});


### PR DESCRIPTION
Allows the user to pass a Google `DataTable` into a chart component as the `data` property. Currently `data` only accepts an array. `DataTable` and the various methods you can use to create that class are documented in the [Google Charts docs](https://developers.google.com/chart/interactive/docs/datatables_dataviews).

Here is an example of usage:

```js
import Route from '@ember/routing/route';

export default Route.extend({

  model() {
    return window.google.visualization.arrayToDataTable([
      ['Year', 'Sales', 'Expenses'],
      ['2004', 1000, 400],
      ['2005', 1170, 460],
    ], false);
  },

});
```

```hbs
{{bar-chart data=data}}
```