### PR TITLE
Fix google.visualization undefined error

### DIFF
--- a/addon/services/google-charts.js
+++ b/addon/services/google-charts.js
@@ -16,13 +16,13 @@ export default Service.extend({
     };
   },
 
+  packagesAreLoaded: false,
+
   loadPackages() {
     const { google: { charts } } = window;
 
     return new RSVP.Promise((resolve, reject) => {
-      const packagesAreLoaded = charts.loader;
-
-      if (packagesAreLoaded) {
+      if (this.packagesAreLoaded) {
         resolve();
       } else {
         charts.load('current', {
@@ -33,6 +33,7 @@ export default Service.extend({
         charts.setOnLoadCallback((ex) => {
           if (ex) { reject(ex); }
 
+          this.packagesAreLoaded = true
           resolve();
         });
       }


### PR DESCRIPTION
This morning we started getting an runtime error in production, even though no code changes had been deployed. window.google.visualization was undefined, thrown by utils/render-chart.

Looks like the packages were never being loaded by services/google-charts/loadPackages() because window.google.charts.loader was already defined. Perhaps google had published an update to https://www.gstatic.com/charts/loader.js?